### PR TITLE
V6 improvement

### DIFF
--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,20 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { advocatesService } from "../../../server/services/advocates";
-import { PaginationDirection } from "../../../server/types";
 
 export async function GET(req: NextRequest) {
   const searchParams = req.nextUrl.searchParams;
 
-  const cursor = searchParams.get("cursor");
   const limit = searchParams.get("limit");
   const search = searchParams.get("search");
-  const direction = searchParams.get("direction") as PaginationDirection;
+  const offset = searchParams.get("offset");
 
   const result = await advocatesService.getAll({
     pagination: {
-      cursor: cursor,
+      offset: offset,
       limit: limit,
-      direction: direction,
     },
     filters: {
       search: search,

--- a/src/app/pages/advocates/store/reducer.ts
+++ b/src/app/pages/advocates/store/reducer.ts
@@ -4,121 +4,120 @@ import { isMultiSelectFilter } from "../../../../utils";
 import { Action, AdvocateActions } from "./types";
 
 export const initialState = {
-    advocates: [] as Advocate[],
-    filteredAdvocates: [] as Advocate[],
-    isFetching: true,
-    isError: false,
-    pagination: {
-        nextCursor: null as number | null,
-        cursorStack: [] as (null | number)[],
-        hasNextData: false as boolean,
-    },
-    filters: { search: "", city: "", specialty: [], degree: "" } as Filters,
+  advocates: [] as Advocate[],
+  filteredAdvocates: [] as Advocate[],
+  isFetching: true,
+  isError: false,
+  pagination: {
+    offset: 0,
+    hasNextData: false,
+    limit: 20,
+  },
+  filters: { search: "", city: "", specialty: [], degree: "" } as Filters,
 };
 
 type State = typeof initialState;
 
 export const reducer = (state: State, action: Action): State => {
-    switch (action.type) {
-        case AdvocateActions.FETCH_START:
-            return { ...state, isFetching: true, isError: false };
+  switch (action.type) {
+    case AdvocateActions.FETCH_START:
+      return { ...state, isFetching: true, isError: false };
 
-        case AdvocateActions.FETCH_ERROR:
-            return { ...state, isFetching: false, isError: true };
+    case AdvocateActions.FETCH_ERROR:
+      return { ...state, isFetching: false, isError: true };
 
-        case AdvocateActions.ADD_FILTER: {
-            const { name, value } = action.payload;
-            let filters = {};
-            if (isMultiSelectFilter(name)) {
-                filters = {
-                    ...state.filters,
-                    [name]: [
-                        ...((state.filters[
-                            name as keyof Filters
-                        ] as string[]) ?? []),
-                        value,
-                    ],
-                };
-            } else {
-                filters = { ...state.filters, [name]: value };
-            }
+    case AdvocateActions.ADD_FILTER: {
+      const { name, value } = action.payload;
+      let filters = {};
+      if (isMultiSelectFilter(name)) {
+        filters = {
+          ...state.filters,
+          [name]: [
+            ...((state.filters[name as keyof Filters] as string[]) ?? []),
+            value,
+          ],
+        };
+      } else {
+        filters = { ...state.filters, [name]: value };
+      }
 
-            return {
-                ...state,
-                filters,
-                pagination: {
-                    ...state.pagination,
-                    nextCursor: null,
-                    cursorStack: [],
-                },
-            };
-        }
-
-        case AdvocateActions.DELETE_FILTER: {
-            const { name, value } = action.payload;
-            let filters = {};
-
-            if (isMultiSelectFilter(name)) {
-                filters = {
-                    ...state.filters,
-                    [name]: (
-                        (state.filters[name as keyof Filters] as string[]) ?? []
-                    ).filter((filterValue) => filterValue !== value),
-                };
-            } else {
-                filters = {
-                    ...state.filters,
-                    [name]: "",
-                };
-            }
-
-            return {
-                ...state,
-                filters,
-                pagination: {
-                    ...state.pagination,
-                    nextCursor: null,
-                    cursorStack: [],
-                },
-            };
-        }
-
-        case AdvocateActions.FETCH_SUCCESS: {
-            const {
-                advocates,
-                nextCursor,
-                direction,
-                activeCursor,
-                hasNextData,
-            } = action.payload;
-            const clonedCursorStack = [...state.pagination.cursorStack];
-
-            if (direction === "prev") {
-                clonedCursorStack.pop();
-            } else if (direction === "next") {
-                const lastCursor =
-                    clonedCursorStack[clonedCursorStack.length - 1];
-                if (lastCursor !== activeCursor) {
-                    clonedCursorStack.push(activeCursor);
-                }
-            }
-
-            return {
-                ...state,
-                filteredAdvocates: advocates,
-                isFetching: false,
-                isError: false,
-                pagination: {
-                    ...state.pagination,
-                    nextCursor,
-                    cursorStack: clonedCursorStack,
-                    hasNextData,
-                },
-                advocates,
-            };
-        }
-
-        default:
-            return state;
+      return {
+        ...state,
+        filters,
+        pagination: {
+          ...state.pagination,
+          offset: 0,
+          hasNextData: false,
+        },
+      };
     }
+
+    case AdvocateActions.DELETE_FILTER: {
+      const { name, value } = action.payload;
+      let filters = {};
+
+      if (isMultiSelectFilter(name)) {
+        filters = {
+          ...state.filters,
+          [name]: (
+            (state.filters[name as keyof Filters] as string[]) ?? []
+          ).filter((filterValue) => filterValue !== value),
+        };
+      } else {
+        filters = {
+          ...state.filters,
+          [name]: "",
+        };
+      }
+
+      return {
+        ...state,
+        filters,
+        pagination: {
+          ...state.pagination,
+          offset: 0,
+          hasNextData: false,
+        },
+      };
+    }
+
+    case AdvocateActions.FETCH_SUCCESS: {
+      const { advocates, hasNextData } = action.payload;
+
+      return {
+        ...state,
+        filteredAdvocates: advocates,
+        isFetching: false,
+        isError: false,
+        pagination: {
+          ...state.pagination,
+          hasNextData,
+        },
+        advocates,
+      };
+    }
+
+    case AdvocateActions.CHANGE_OFFSET: {
+      const { amount, changeAction } = action.payload;
+      let updatedOffset =
+        changeAction === "increment"
+          ? state.pagination.offset + amount
+          : state.pagination.offset - amount;
+
+      if (updatedOffset < 0) {
+        updatedOffset = 0;
+      }
+
+      return {
+        ...state,
+        pagination: {
+          ...state.pagination,
+          offset: updatedOffset,
+        },
+      };
+    }
+
+    default:
+      return state;
+  }
 };

--- a/src/app/pages/advocates/store/types.ts
+++ b/src/app/pages/advocates/store/types.ts
@@ -4,11 +4,10 @@ export enum AdvocateActions {
   FETCH_START = "FETCH_START",
   FETCH_SUCCESS = "FETCH_SUCCESS",
   FETCH_ERROR = "FETCH_ERROR",
-  GET_PREV_DATA_FROM_CACHE = "GET_PREV_DATA_FROM_CACHE",
-  GET_NEXT_DATA_FROM_CACHE = "GET_NEXT_DATA_FROM_CACHE",
   SEARCH_TEXT = "SEARCH_TEXT",
   ADD_FILTER = "SET_FILTER",
   DELETE_FILTER = "DELETE_FILTER",
+  CHANGE_OFFSET = "CHANGE_OFFSET",
 }
 
 interface FetchStartAction {
@@ -18,27 +17,13 @@ interface FetchStartAction {
 interface FetchSuccessAction {
   type: AdvocateActions.FETCH_SUCCESS;
   payload: {
-    nextCursor: number | null;
-    activeCursor: number | null;
     advocates: Advocate[];
-    direction: "next" | "prev" | null;
     hasNextData: boolean;
   };
 }
 
 interface FetchErrorAction {
   type: AdvocateActions.FETCH_ERROR;
-}
-
-interface ClickPrevAction {
-  type: AdvocateActions.GET_PREV_DATA_FROM_CACHE;
-}
-
-interface ClickNextAction {
-  type: AdvocateActions.GET_NEXT_DATA_FROM_CACHE;
-  payload: {
-    data: Advocate[];
-  };
 }
 
 interface SearchTextAction {
@@ -64,12 +49,19 @@ interface DeleteFilterValue {
   };
 }
 
+export interface ChangeOffset {
+  type: AdvocateActions.CHANGE_OFFSET;
+  payload: {
+    changeAction: "increment" | "decrement";
+    amount: number;
+  };
+}
+
 export type Action =
   | FetchStartAction
   | FetchSuccessAction
   | FetchErrorAction
-  | ClickPrevAction
-  | ClickNextAction
   | SearchTextAction
   | AddFilterValue
-  | DeleteFilterValue;
+  | DeleteFilterValue
+  | ChangeOffset;

--- a/src/server/types/pagination.ts
+++ b/src/server/types/pagination.ts
@@ -2,6 +2,5 @@ export type PaginationDirection = "prev" | "next" | null;
 
 export interface Pagination {
   limit: string | null;
-  cursor: string | null;
-  direction: PaginationDirection;
+  offset: string | null;
 }

--- a/src/server/types/pagination.ts
+++ b/src/server/types/pagination.ts
@@ -1,5 +1,3 @@
-export type PaginationDirection = "prev" | "next" | null;
-
 export interface Pagination {
   limit: string | null;
   offset: string | null;

--- a/src/services/advocates.ts
+++ b/src/services/advocates.ts
@@ -11,14 +11,14 @@ class Advocates {
   }
   async getAdvocates(
     pagination: Pagination,
-    filters?: Filters
+    filters: Filters
   ): Promise<{
     advocates: Advocate[];
     nextCursor: number | null;
     hasNextData: boolean;
   }> {
     const paginationQuery = buildQuery(pagination);
-    const filtersQuery = buildQuery(filters ?? {});
+    const filtersQuery = buildQuery(filters);
     let finalUrl = `${this.baseUrl}?${paginationQuery}`;
 
     if (filtersQuery) {

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,5 +1,4 @@
 export interface Pagination {
-  cursor: number | null;
-  limit?: number;
-  direction: "next" | "prev" | null;
+  limit: number | null;
+  offset: number;
 }


### PR DESCRIPTION
## Summary

Switch pagination strategy from cursor-based to offset-based for advocates data.

## Reasons for Change

1. **Low write frequency**: Advocates data does not change often (i.e., insert/update/delete operations are rare), making offset pagination a suitable and stable approach.
2. **Manageable dataset size**: We expect at most ~10,000 advocates in the database. Offset-based pagination performs well at this scale and avoids unnecessary complexity.
3. **Frontend simplification**: Cursor-based pagination required tracking and storing previous/next cursors on the client, adding to state management complexity. Offset-based pagination simplifies the logic significantly.
4. **Sorting ease**: Offset-based pagination integrates more cleanly with sort operations. Cursor pagination with non-unique fields (e.g., years of experience) introduced additional composite key challenges which are now avoided.

## Notes

- Existing frontend components were updated to work with `offset` and `limit`.
- Backend service was refactored to return paginated data using offsets.
- `hasNextData` flag is still supported for disabling/enabling pagination controls on the UI.
