### PR TITLE
Encode uri components

### DIFF
--- a/src/utils/build-query.ts
+++ b/src/utils/build-query.ts
@@ -5,11 +5,15 @@ import { Sort } from "../types/sort";
 export const buildQuery = (filters: Filters | Pagination | Sort) => {
   const query: string[] = [];
 
-  Object.entries(filters).forEach((entry) => {
-    if (entry[1] && !Array.isArray(entry[1])) {
-      query.push(`${entry[0]}=${entry[1]}`);
-    } else if (Array.isArray(entry[1]) && entry[1].length > 0) {
-      query.push(`${entry[0]}=${entry[1].join("_")}`);
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value && !Array.isArray(value)) {
+      query.push(
+        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
+      );
+    } else if (Array.isArray(value) && value.length > 0) {
+      query.push(
+        `${encodeURIComponent(key)}=${encodeURIComponent(value.join("_"))}`
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

Fixes incorrect query string generation in `buildQuery` by properly encoding query values using `encodeURIComponent`.

## Problem

The `buildQuery` function previously constructed URLs without encoding special characters. This caused issues when values (e.g., "Weight loss & nutrition") contained reserved characters like `&`, which broke the query structure.

Example of broken URL: `/api/advocates?specialty=Weight loss & nutrition`

